### PR TITLE
refactor: Added support for masking multiline secrets

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,11 @@ async function run(): Promise<void> {
     // Access and export each secret.
     for (const ref of secretsRefs) {
       const value = await client.accessSecret(ref.selfLink());
-      core.setSecret(value);
+
+      // Split multiline secrets by line break and mask each line.
+      // Read more here: https://github.com/actions/runner/issues/161
+      value.split(/\r\n|\r|\n/g).forEach((line) => core.setSecret(line));
+
       core.setOutput(ref.output, value);
     }
   } catch (error) {


### PR DESCRIPTION
Hey there! So, I was recently testing out this action by pulling an ssh key from Secret Manager. I noticed in the logs, that the secret was not properly masked because the `core.setSecret` method [does not handle line breaks](https://github.com/actions/runner/issues/161). This PR adds functionality to split secret values, via regex, and adds a mask on each line as suggested by the [warnings within the docs](https://github.com/actions/toolkit/blob/main/docs/commands.md#register-a-secret). 

I took a look at the contributing guidelines and signed the CLA. Please let me know if there is anything else I can do to help.