### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ jobs:
 
     ```yaml
     secrets: |-
-      output1:my-project/my-secret1
-      output2:my-project/my-secret2
+      input1:my-project/my-secret1
+      input2:my-project/my-secret2
     ```
 
     Secrets can be referenced using the following formats:


### PR DESCRIPTION
Fix small typo in `inputs` section of the readme