### PR TITLE
Trim whitespace around secret references

### DIFF
--- a/src/reference.ts
+++ b/src/reference.ts
@@ -43,8 +43,15 @@ export class Reference {
 
     this.output = sParts[0].trim();
 
-    const ref = sParts.slice(1).join(':');
-    const refParts = ref.split('/');
+    // Trim each piece and remove empty entries
+    const refParts =
+      sParts
+        ?.slice(1)
+        ?.at(0)
+        ?.split('/')
+        ?.map((p) => (p || '').trim())
+        ?.filter((p) => p !== '') || [];
+
     switch (refParts.length) {
       // projects/<p>/locations/<l>/secrets/<s>/versions/<v>
       case 8: {

--- a/tests/reference.test.ts
+++ b/tests/reference.test.ts
@@ -42,6 +42,14 @@ test('Reference', { concurrency: true }, async (suite) => {
       expected: 'projects/my-project/secrets/my-secret/versions/latest',
     },
     {
+      input: 'out: my-project/my-secret',
+      expected: 'projects/my-project/secrets/my-secret/versions/latest',
+    },
+    {
+      input: 'out : projects/ my-project/   secrets/	my-secret',
+      expected: 'projects/my-project/secrets/my-secret/versions/latest',
+    },
+    {
       input: '',
       error: 'TypeError',
     },


### PR DESCRIPTION
Fixes https://github.com/google-github-actions/get-secretmanager-secrets/issues/303